### PR TITLE
Refactored ping command responses into text file

### DIFF
--- a/src/replies.txt
+++ b/src/replies.txt
@@ -1,0 +1,55 @@
+Pong!
+Marco!
+Roger!
+I hear ya!
+Good day.
+Hello!
+What's up?
+I'm alive!
+Hearing you loud and clear.
+PiNg!
+Yep, still here.
+Nah, totally offline.
+Sup?
+What's a bot gotta do to get some sleep around here?
+Running.
+Uptime is my prime focus.
+It... It's not like I wanted to be pinged by you... :blush:
+!gniP
+*Snore* :zzz:
+Cheers!
+Yes?
+I was young once.
+Do bots dream of electric wumpuses?
+>TFW you get pinged by some guy and have to respond
+That's a nice name.
+I think that you should relax, you look a little tense.
+Wanna hear a joke?
+So I said, 0100101001001111001, and then he said 00101001001111101101, and we both segfaulted. :laughing:
+Of course you would ping me right now, at the worst possible moment...
+Try a different command.
+.....HA just kidding I'm still here.
+I wanted to be a protein folder, but noooo....
+I'm coded in rust, but I'm not rusty!
+BlueprintBot? He's okay. Don't really know him too well.
+Send your dankest memes.
+Actively maintained!
+Haven't broken yet!
+:thinking:
+I main Bastion and Zenyatta in Overwatch.
+Bots cannot have friends. Sorry.
+Do you like my steel plating?
+0 and 1 are all I need.
+Heh, you humans... Typing manually and stuff.... I don't get it.
+Never forget #BotsRights
+EXTERMIN... oh nevermind.
+Fun fact: I take about an hour to compile from scratch.
+Over 1700 lines of code!
+Will you be the 1 to my 0?
+*Tung!*
+*Servus!*
+*Hallo!*
+*Ahoj!*
+*Bonjour!*
+*Buon giorno!*
+*Wie gehts?*

--- a/src/simple_commands.rs
+++ b/src/simple_commands.rs
@@ -8,31 +8,14 @@ use std::process;
 use self::serenity::utils::Colour;
 use constants::*;
 
+lazy_static! {
+    static ref REPLIES: Vec<&'static str> = include_str!("replies.txt").lines().collect();
+}
+
 /// Your standard ping command, replies with random replies {{{1
 command!(ping(_context, message) {
-    let replies = ["Pong!", "Marco!", "Roger!", "I hear ya!",
-    "Good day.", "Hello!", "What's up?","I'm alive!",
-    "Hearing you loud and clear.","PiNg!", "Yep, still here.",
-    "Nah, totally offline.", "Sup?", "What's a bot gotta do to get some sleep around here?",
-    "Running.", "Uptime is my prime focus.", "It... It's not like I wanted to be pinged by you... :blush:",
-    "!gniP", "*Snore* :zzz:", "Cheers!", "Yes?", "I was young once.",
-    "Do bots dream of electric wumpuses?", ">TFW you get pinged by some guy and have to respond",
-    "That's a nice name.", "I think that you should relax, you look a little tense.",
-    "Wanna hear a joke?", "So I said, 0100101001001111001, and then he said 00101001001111101101, and we both segfaulted. :laughing:",
-    "Of course you would ping me right now, at the worst possible moment...", "Try a different command.", ".....HA just kidding I'm still here.",
-    "I wanted to be a protein folder, but noooo....", "I'm coded in rust, but I'm not rusty!",
-    "BlueprintBot? He's okay. Don't really know him too well.", "Send your dankest memes.",
-    "Actively maintained!", "Haven't broken yet!", ":thinking:", "I main Bastion and Zenyatta in Overwatch.",
-    "Bots cannot have friends. Sorry.", "Do you like my steel plating?", "0 and 1 are all I need.",
-    "Heh, you humans... Typing manually and stuff.... I don't get it.", "Never forget #BotsRights",
-    "EXTERMIN... oh nevermind.", "Fun fact: I take about an hour to compile from scratch.",
-    "Over 1700 lines of code!", "Will you be the 1 to my 0?",
-    // Other languages
-    "*Tung!*", "*Servus!*", "*Hallo!*", "*Ahoj!*", "*Bonjour!*",
-    "*Buon giorno!*", "*Wie gehts?*"];
-    let random = rand::thread_rng().gen_range(0, replies.len());
-
-    reply_into_chat(&message, replies[random]);
+    let reply = rand::thread_rng().choose(&REPLIES).unwrap();
+    reply_into_chat(&message, reply);
 });
 
 /// Stops the bot, shutting down the process. {{{1


### PR DESCRIPTION
Keeping all the ping replies as an inline array felt a bit messy. I moved them into their own file which can be more easily edited. The file is included at compile time and split into individual responses once at runtime via lazy_static.