### PR TITLE
Replaced make_log_entry with log module

### DIFF
--- a/src/common_funcs.rs
+++ b/src/common_funcs.rs
@@ -1,7 +1,5 @@
 /// A file containing functions, and small commands
 
-use chrono::Utc as UTC;
-
 use serenity;
 use serenity::model::Message;
 use serenity::utils::Colour;
@@ -9,13 +7,6 @@ use serenity::utils::Colour;
 use std::fmt::Display;
 
 use constants::*;
-
-/// Makes a log entry, by prepending the time and date of the entry to what's {{{1
-/// provided to the function.
-pub fn make_log_entry(entry: String, kind: &str) {
-    let timestamp: String = UTC::now().to_rfc2822();
-    println!("[{} at {}] {}", kind, timestamp, entry);
-}
 
 /// Sends a simple error embed. Provide the reason for erroring. {{{1
 pub fn send_error_embed(message: &Message, reason: &str) -> serenity::Result<Message> {
@@ -48,14 +39,10 @@ where
     T: Display,
 {
     if let Err(error) = message.reply(format!("{}", speech).as_str()) {
-        make_log_entry(
-            format!(
-                "Unable to send reply message: {}. Error is {}",
-                speech,
-                error
-            ),
-            "Error",
-        );
+        log_error!(
+            "Unable to send reply message: {}. Error is {}",
+            speech,
+            error);
     }
 }
 
@@ -66,14 +53,10 @@ where
     T: Display,
 {
     if let Err(error) = message.channel_id.say(format!("{}", speech).as_str()) {
-        make_log_entry(
-            format!(
-                "Unable to send reply message: {}. Error is {}",
-                speech,
-                error
-            ),
-            "Error",
-        );
+        log_error!(
+            "Unable to send reply message: {}. Error is {}",
+            speech,
+            error);
     }
 }
 

--- a/src/faq_system.rs
+++ b/src/faq_system.rs
@@ -238,16 +238,9 @@ pub fn write_faq_json(value: JsonValue, guild: &GuildId) {
 
     // Write json to file
     if let Err(error) = value.write(&mut file) {
-        make_log_entry(
-            format!(
-                "Error writing to json file,
-            aborting with error: {:?}",
-                error
-            ),
-            "Error",
-        );
+        log_error!("Error writing to json file, aborting with error: {:?}", error);
     } else {
-        make_log_entry(format!("Wrote to json file: {}", faq_file), "Info");
+        log_info!("Wrote to json file: {}", faq_file);
     }
 }
 
@@ -304,7 +297,7 @@ pub fn get_faq_json(guild: &GuildId, message: &Message) -> JsonValue {
             match json::parse(data) {
                 Ok(result) => result,
                 Err(_) => {
-                    make_log_entry("Unable to parse json from faqs file.".to_owned(), "Error");
+                    log_error!("Unable to parse json from faqs file.");
                     say_into_chat(
                         &message,
                         "Sorry, I couldn't read the database for this server.",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,10 @@ extern crate reqwest;
 #[macro_use]
 extern crate serenity;
 
+// log mod must be declared before the others for the macros to work
+#[macro_use]
+pub mod log;
+
 pub mod common_funcs;
 pub mod constants;
 mod faq_system;

--- a/src/log.rs
+++ b/src/log.rs
@@ -1,0 +1,42 @@
+use chrono::Utc;
+
+pub fn current_rfc2882_string() -> String {
+    Utc::now().to_rfc2822()
+}
+
+/// Makes a log entry, by prepending the time and date of the entry to what's {{{1
+/// provided to the function.
+#[macro_export]
+macro_rules! make_log_entry {
+    ($kind:expr, $arg:expr) => (make_log_entry!($kind, "{}", $arg));
+    ($kind:expr, $fmt:expr, $($arg:expr),*) => {{
+        let timestamp = $crate::log::current_rfc2882_string();
+        let entry = format!($fmt, $($arg),*);
+        println!("[{} at {}] {}", $kind, timestamp, entry);
+    }};
+}
+
+#[macro_export]
+macro_rules! log_info {
+    ($($arg:expr),+) => (make_log_entry!("Info", $($arg),+));
+}
+
+#[macro_export]
+macro_rules! log_init {
+    ($($arg:expr),+) => (make_log_entry!("Init", $($arg),+));
+}
+
+#[macro_export]
+macro_rules! log_error {
+    ($($arg:expr),+) => (make_log_entry!("Error", $($arg),+));
+}
+
+#[macro_export]
+macro_rules! log_prefix {
+    ($($arg:expr),+) => (make_log_entry!("Prefix", $($arg),+));
+}
+
+#[macro_export]
+macro_rules! log_status {
+    ($($arg:expr),+) => (make_log_entry!("Status", $($arg),+));
+}

--- a/src/prefix_control.rs
+++ b/src/prefix_control.rs
@@ -35,10 +35,9 @@ command!(register_prefix(_c, m, args) {
     // Edit prefixes file with new prefix
     backup_prefixes();
 
-    make_log_entry(format!("Changed prefix of server id {:?}, to new prefix {}",
+    log_prefix!("Changed prefix of server id {:?}, to new prefix {}",
                            m.guild_id().unwrap(),
-                           prefix),
-                           "Prefix");
+                           prefix);
 });
 
 // Tests {{{1

--- a/src/web_requesting.rs
+++ b/src/web_requesting.rs
@@ -47,7 +47,7 @@ command!(fff(_context, msg) {
 
                         // Send the FFF embed detailing it
                         if let Err(error) = send_fff_embed(&message, update_time, link, number) {
-                            make_log_entry(format!("Got error sending embed for fff results, {}", error), "Error");
+                            log_error!("Got error sending embed for fff results, {}", error);
                             reply_into_chat(&message, "Sorry, I was unable to send the results as an embed. Instead, have them plain:");
                             say_into_chat(&message, format!("Latest FFF as of roughly {}:\n{}", update_time, link).as_str());
                         }
@@ -111,7 +111,7 @@ command!(version(_context, msg) {
         // Check that both the finds succesfully found what we were looking for
         if !latest_stable.is_empty() && !latest_experimental.is_empty() {
             if let Err(_) = send_version_embed(&message, &latest_stable, &latest_experimental) {
-                make_log_entry("Unable to send an embed of the results of a version query.".to_owned(), "Error");
+                log_error!("Unable to send an embed of the results of a version query.");
                 say_into_chat(&message, format!("I got a result, but was unable to send an embed of the results.
                               \nInstead, have them plain:\n Latest Stable: {}\nLatest experimental: {}", latest_stable, latest_experimental));
             }


### PR DESCRIPTION
Upon review, the existing function "make_log_entry" is used commonly alongside the "format" macro. Likewise, the String argument causes needless heap allocations in many of the use cases. Thus, the log module is born and within it contains several log functions. Within the new log module there are several logging functions which reimpliment the existing function without breaking backward compatibility with the previous logging style.

Usage:

log_info!("single comment str")
or
log_info!("format string with {} {} {} {}", "variable", "number", "of", "args");

alternatively

make_log_entry!("Kind", "format string with {} {} {} {}", "variable", "number", "of", "args);
// Currently this is only used for CMD-Error since it is only used once